### PR TITLE
Fix default Helm values for KAgent

### DIFF
--- a/kagent/values.yaml
+++ b/kagent/values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 
 global:
-  tag: "0.3.1"
+  tag: "0.4.3"
 
 # https://kagent.dev/docs/getting-started/configuring-providers
 providers:
@@ -42,7 +42,8 @@ controller:
   # -- Namespaces the controller should watch.
   # If empty, the controller will watch ONLY release namespace.
   # @default -- [] (watches release namespace)
-  watchNamespaces: []
+  watchNamespaces:
+    - kagent
   #  - watch-ns-1
   #  - watch-ns-2
 


### PR DESCRIPTION
## Summary
- set a valid image tag that includes the `tools` image
- scope the controller to the `kagent` namespace so the flag doesn't produce an empty value

## Testing
- `pre-commit run --files kagent/values.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6879b53cbbdc8325955b00932f80e475