### PR TITLE
Fix Helm tag precedence for tools container

### DIFF
--- a/helm/kagent/templates/deployment.yaml
+++ b/helm/kagent/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ coalesce .Values.global.tag .Values.controller.image.tag .Chart.Version }}"
+          image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ coalesce .Values.controller.image.tag .Values.global.tag .Chart.Version }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
@@ -80,7 +80,7 @@ spec:
         - name: app
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.app.image.registry }}/{{ .Values.app.image.repository }}:{{ coalesce .Values.global.tag .Values.app.image.tag .Chart.Version }}"
+          image: "{{ .Values.app.image.registry }}/{{ .Values.app.image.repository }}:{{ coalesce .Values.app.image.tag .Values.global.tag .Chart.Version }}"
           imagePullPolicy: {{ .Values.app.image.pullPolicy }}
           env:
             - name: LOG_LEVEL
@@ -113,7 +113,7 @@ spec:
         - name: ui
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.ui.image.registry }}/{{ .Values.ui.image.repository }}:{{ coalesce .Values.global.tag .Values.ui.image.tag .Chart.Version }}"
+          image: "{{ .Values.ui.image.registry }}/{{ .Values.ui.image.repository }}:{{ coalesce .Values.ui.image.tag .Values.global.tag .Chart.Version }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           env:
             - name: NEXT_PUBLIC_BACKEND_URL
@@ -141,7 +141,7 @@ spec:
           - "{{ .Values.service.ports.tools.targetPort }}"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.tools.image.registry }}/{{ .Values.tools.image.repository }}:{{ coalesce .Values.global.tag .Values.tools.image.tag .Chart.Version }}"
+          image: "{{ .Values.tools.image.registry }}/{{ .Values.tools.image.repository }}:{{ coalesce .Values.tools.image.tag .Values.global.tag .Chart.Version }}"
           imagePullPolicy: {{ .Values.tools.image.pullPolicy }}
           resources:
             {{- toYaml .Values.tools.resources | nindent 12 }}

--- a/helm/kagent/tests/deployment_test.yaml
+++ b/helm/kagent/tests/deployment_test.yaml
@@ -59,6 +59,18 @@ tests:
           path: spec.template.spec.containers[2].image
           value: cr.kagent.dev/kagent-dev/kagent/ui:v1.0.0
 
+  - it: should prefer tools tag over global tag when provided
+    set:
+      global:
+        tag: "v1.0.0"
+      tools:
+        image:
+          tag: "0.0.7"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[3].image
+          value: ghcr.io/kagent-dev/kagent/tools:0.0.7
+
   - it: should have correct resource limits and requests
     asserts:
       - equal:


### PR DESCRIPTION
## Summary
- ensure deployment images favor component tag over global tag
- add helm unittest for tools tag override

## Testing
- `pre-commit run --files helm/kagent/templates/deployment.yaml helm/kagent/tests/deployment_test.yaml`
- `helm unittest helm/kagent`

------
https://chatgpt.com/codex/tasks/task_e_687b36abc6f08325b4830bec22405cda